### PR TITLE
Fix missing GetResponseCodeMeaning method

### DIFF
--- a/EcommerceBe/Services/Interfaces/IVNPayService.cs
+++ b/EcommerceBe/Services/Interfaces/IVNPayService.cs
@@ -1,4 +1,4 @@
-﻿using EcommerceBe.Dto;
+using EcommerceBe.Dto;
 
 namespace EcommerceBe.Services.Interfaces
 {
@@ -7,5 +7,6 @@ namespace EcommerceBe.Services.Interfaces
         Task<PaymentResponseDto> CreatePaymentAsync(PaymentRequestDto request);
         Task<bool> ValidateCallbackAsync(PaymentCallbackDto callback);
         Task<PaymentCallbackDto> ProcessCallbackAsync(IQueryCollection queryParams);
+        string GetResponseCodeMeaning(string responseCode);
     }
 }

--- a/EcommerceBe/Services/VNPayService.cs
+++ b/EcommerceBe/Services/VNPayService.cs
@@ -1,4 +1,4 @@
-﻿using EcommerceBe.Dto;
+using EcommerceBe.Dto;
 using EcommerceBe.Services.Interfaces;
 using Microsoft.Extensions.Options;
 using System.Globalization;
@@ -129,6 +129,27 @@ namespace EcommerceBe.Services
         private string GetIpAddress()
         {
             return "127.0.0.1"; // In production, get actual client IP
+        }
+
+        public string GetResponseCodeMeaning(string responseCode)
+        {
+            return responseCode switch
+            {
+                "00" => "Giao dịch thành công",
+                "01" => "Giao dịch chưa hoàn tất",
+                "02" => "Giao dịch bị lỗi",
+                "04" => "Giao dịch đảo (Khách hàng đã bị trừ tiền tại Ngân hàng nhưng GD chưa thành công ở VNPAY)",
+                "05" => "VNPAY đang xử lý giao dịch này",
+                "06" => "VNPAY đã gửi yêu cầu hoàn tiền sang Ngân hàng",
+                "07" => "Giao dịch bị nghi ngờ gian lận",
+                "09" => "Giao dịch không thành công do: Thẻ/Tài khoản bị khóa",
+                "13" => "Giao dịch không thành công do: Nhập sai mật khẩu xác thực giao dịch (OTP)",
+                "65" => "Giao dịch không thành công do: Tài khoản không đủ số dư",
+                "75" => "Ngân hàng thanh toán đang bảo trì",
+                "79" => "Giao dịch không thành công do: Nhập sai mật khẩu thanh toán",
+                "99" => "Các lỗi khác (lỗi còn lại, không có trong danh sách mã lỗi đã liệt kê)",
+                _ => $"Mã lỗi không xác định: {responseCode}"
+            };
         }
     }
 


### PR DESCRIPTION
Add `GetResponseCodeMeaning` to `IVNPayService` and `VNPayService` to provide human-readable VNPay response code meanings.

---
<a href="https://cursor.com/background-agent?bcId=bc-414b2a65-be79-4dad-ae98-60eaa87980aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-414b2a65-be79-4dad-ae98-60eaa87980aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>